### PR TITLE
Add support for docker-compose based install.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .git
+.env

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ git clone https://github.com/magfest/magbot.git && cd magbot
 ./run-dev.sh magbot-username xoxb-XXXXXXXXXXXX
 ```
 
+#### Local Dev Environment (Docker Compose)
+* Install [docker](https://www.docker.com)
+* Clone the magbot repository:
+```
+git clone https://github.com/magfest/magbot.git && cd magbot
+```
+* Copy the `env.sample` file to `.env`
+* Edit `.env` and add your bot's username and API token.
+* !!! VERY IMPORTANT !!! Do _NOT_ put your login info into `env.sample`.
+* Run magbot with
+```
+docker-compose up
+```
+
 #### Developing
 * You can now interact with your local magbot on the [test Slack workspace](https://magfest-test.slack.com)
 * In a DM with your magbot, type `!help` to get a list of commands

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.2'
+services:
+  magbot:
+    image: magfest/docker-errbot:latest
+    volumes:
+    - type: bind
+      source: ./config-dev.py
+      target: /srv/config.py
+    - type: bind
+      source: .
+      target: /srv/plugins/magbot
+    env_file: .env

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,3 @@
+# Save this file as .env
+BOT_USERNAME=<username>
+BOT_TOKEN=<token>


### PR DESCRIPTION
I'm currently developing on a Windows box and a Linux shell script won't run. This also moves the config variables out of the command line and into a file which `.gitignore` already knows to not commit to the repo.