### PR TITLE
added onsite to environment list

### DIFF
--- a/plugins/infrastructure.py
+++ b/plugins/infrastructure.py
@@ -2,7 +2,7 @@ from errbot import BotPlugin
 from magbot import FabricMixin, MagbotMixin, SaltMixin
 
 
-ENVS = ['prod', 'staging', 'load', 'dev']
+ENVS = ['prod', 'staging', 'load', 'dev', 'onsite']
 EVENT_NAMES = ['super', 'labs', 'stock', 'west']
 
 


### PR DESCRIPTION
I created a new ``onsite`` environment, but I can't actually deploy to it with magbot!  This adds that ability.

I confess that I have no idea offhand how to update MAGBot once this is merged - I assume it's in the README, which I'll take the time to actually read tomorrow.  In the meantime, if @kitsuta needs to deploy anything to the onsite server between now and when this gets merged/deployed, she can log into mcp and run this command:

```
salt onsite.uber.magfest.org state.apply
```